### PR TITLE
corrigindo problema de importação do db.sql

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,85 +1,86 @@
 {
-    "name": "Code Flix",
-    "version": "0.0.1",
-    "author": "Ionic Framework",
-    "homepage": "http://ionicframework.com/",
-    "private": true,
-    "scripts": {
-        "clean": "ionic-app-scripts clean",
-        "build": "ionic-app-scripts build",
-        "lint": "ionic-app-scripts lint",
-        "ionic:build": "ionic-app-scripts build",
-        "ionic:serve": "ionic-app-scripts serve"
+  "name": "CodeFlix",
+  "version": "0.0.1",
+  "author": "Ionic Framework",
+  "homepage": "http://ionicframework.com/",
+  "private": true,
+  "scripts": {
+    "clean": "ionic-app-scripts clean",
+    "build": "ionic-app-scripts build",
+    "lint": "ionic-app-scripts lint",
+    "ionic:build": "ionic-app-scripts build",
+    "ionic:serve": "ionic-app-scripts serve"
+  },
+  "config": {
+    "ionic_webpack": "./webpack.config.js"
+  },
+  "dependencies": {
+    "@angular/common": "4.1.3",
+    "@angular/compiler": "4.1.3",
+    "@angular/compiler-cli": "4.1.3",
+    "@angular/core": "4.1.3",
+    "@angular/forms": "4.1.3",
+    "@angular/http": "4.1.3",
+    "@angular/platform-browser": "4.1.3",
+    "@angular/platform-browser-dynamic": "4.1.3",
+    "@ionic-native/core": "3.12.1",
+    "@ionic-native/facebook": "^4.1.0",
+    "@ionic-native/splash-screen": "3.12.1",
+    "@ionic-native/sqlite": "^4.3.2",
+    "@ionic-native/sqlite-porter": "^4.3.2",
+    "@ionic-native/status-bar": "3.12.1",
+    "@ionic-native/streaming-media": "^4.3.1",
+    "@ionic/app-scripts": "^1.3.12",
+    "@ionic/storage": "2.0.1",
+    "angular2-jwt": "^0.2.3",
+    "angular2-moment": "^1.3.3",
+    "angular2-text-mask": "^8.0.1",
+    "cordova-android": "^6.2.3",
+    "cordova-browser": "^4.1.0",
+    "cordova-plugin-console": "^1.0.5",
+    "cordova-plugin-device": "^1.1.4",
+    "cordova-plugin-facebook4": "^1.9.1",
+    "cordova-plugin-splashscreen": "^4.0.3",
+    "cordova-plugin-statusbar": "^2.2.2",
+    "cordova-plugin-streaming-media": "^1.0.2",
+    "cordova-plugin-whitelist": "^1.3.1",
+    "cordova-sqlite-storage": "^2.0.4",
+    "crypto-md5": "^1.0.0",
+    "ionic-angular": "3.5.3",
+    "ionic-plugin-keyboard": "^2.2.1",
+    "ionicons": "3.0.0",
+    "raw-loader": "^0.5.1",
+    "rxjs": "5.4.0",
+    "scriptjs": "^2.5.8",
+    "sw-toolbox": "3.6.0",
+    "uk.co.workingedge.cordova.plugin.sqliteporter": "^1.0.1",
+    "zone.js": "0.8.12"
+  },
+  "devDependencies": {
+    "@ionic/app-scripts": "2.0.2",
+    "ionic": "3.9.2",
+    "typescript": "2.3.4"
+  },
+  "description": "An Ionic project",
+  "cordova": {
+    "plugins": {
+      "cordova-plugin-facebook4": {
+        "APP_ID": "410346219362259",
+        "APP_NAME": "CodeFlix"
+      },
+      "cordova-plugin-console": {},
+      "cordova-plugin-device": {},
+      "cordova-plugin-splashscreen": {},
+      "cordova-plugin-statusbar": {},
+      "cordova-plugin-whitelist": {},
+      "ionic-plugin-keyboard": {},
+      "com.hutchind.cordova.plugins.streamingmedia": {},
+      "uk.co.workingedge.cordova.plugin.sqliteporter": {},
+      "cordova-sqlite-storage": {}
     },
-    "config": {
-        "ionic_webpack": "./webpack.config.js"
-    },
-    "dependencies": {
-        "@angular/common": "4.1.3",
-        "@angular/compiler": "4.1.3",
-        "@angular/compiler-cli": "4.1.3",
-        "@angular/core": "4.1.3",
-        "@angular/forms": "4.1.3",
-        "@angular/http": "4.1.3",
-        "@angular/platform-browser": "4.1.3",
-        "@angular/platform-browser-dynamic": "4.1.3",
-        "@ionic-native/core": "3.12.1",
-        "@ionic-native/facebook": "^4.1.0",
-        "@ionic-native/splash-screen": "3.12.1",
-        "@ionic-native/sqlite": "^4.3.2",
-        "@ionic-native/sqlite-porter": "^4.3.2",
-        "@ionic-native/status-bar": "3.12.1",
-        "@ionic-native/streaming-media": "^4.3.1",
-        "@ionic/storage": "2.0.1",
-        "angular2-jwt": "^0.2.3",
-        "angular2-moment": "^1.3.3",
-        "angular2-text-mask": "^8.0.1",
-        "com.hutchind.cordova.plugins.streamingmedia": "~0.1.4",
-        "cordova-android": "^6.2.3",
-        "cordova-browser": "^4.1.0",
-        "cordova-plugin-console": "^1.0.5",
-        "cordova-plugin-device": "^1.1.4",
-        "cordova-plugin-facebook4": "^1.9.1",
-        "cordova-plugin-splashscreen": "^4.0.3",
-        "cordova-plugin-statusbar": "^2.2.2",
-        "cordova-plugin-streaming-media": "^1.0.2",
-        "cordova-plugin-whitelist": "^1.3.1",
-        "cordova-sqlite-storage": "^2.0.4",
-        "crypto-md5": "^1.0.0",
-        "ionic-angular": "3.5.3",
-        "ionic-plugin-keyboard": "^2.2.1",
-        "ionicons": "3.0.0",
-        "rxjs": "5.4.0",
-        "scriptjs": "^2.5.8",
-        "sw-toolbox": "3.6.0",
-        "uk.co.workingedge.cordova.plugin.sqliteporter": "^1.0.1",
-        "zone.js": "0.8.12"
-    },
-    "devDependencies": {
-        "@ionic/app-scripts": "2.0.2",
-        "ionic": "3.9.2",
-        "typescript": "2.3.4"
-    },
-    "description": "An Ionic project",
-    "cordova": {
-        "plugins": {
-            "cordova-plugin-facebook4": {
-                "APP_ID": "410346219362259",
-                "APP_NAME": "CodeFlix"
-            },
-            "cordova-plugin-console": {},
-            "cordova-plugin-device": {},
-            "cordova-plugin-splashscreen": {},
-            "cordova-plugin-statusbar": {},
-            "cordova-plugin-whitelist": {},
-            "ionic-plugin-keyboard": {},
-            "com.hutchind.cordova.plugins.streamingmedia": {},
-            "uk.co.workingedge.cordova.plugin.sqliteporter": {},
-            "cordova-sqlite-storage": {}
-        },
-        "platforms": [
-            "android",
-            "browser"
-        ]
-    }
+    "platforms": [
+      "android",
+      "browser"
+    ]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,8 @@
   "compileOnSave": false,
   "atom": {
     "rewriteTsconfig": false
-  }
+  },
+  "files": [
+    "typings/sql.d.ts"
+  ]
 }

--- a/typings/sql.d.ts
+++ b/typings/sql.d.ts
@@ -1,0 +1,4 @@
+declare module "*.sql" {
+    let sql: string;
+    export = sql;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,19 +3,12 @@ var webpack = require('webpack');
 var ionicWebpackFactory = require(process.env.IONIC_WEBPACK_FACTORY);
 var envVars = require('./.env.json');
 
-var ModuleConcatPlugin = require('webpack/lib/optimize/ModuleConcatenationPlugin');
-
-var prodPlugins = [];
-if (process.env.IONIC_ENV === 'prod') {
-    prodPlugins.push(new ModuleConcatPlugin());
-}
-
 module.exports = {
     entry: process.env.IONIC_APP_ENTRY_POINT,
     output: {
         path: '{{BUILD}}',
         publicPath: 'build/',
-        filename: '[name].js',
+        filename: process.env.IONIC_OUTPUT_JS_FILE_NAME,
         devtoolModuleFilenameTemplate: ionicWebpackFactory.getSourceMapperFunction(),
     },
     devtool: process.env.IONIC_SOURCE_MAP_TYPE,
@@ -38,17 +31,20 @@ module.exports = {
             {
                 test: /\.js$/,
                 loader: process.env.IONIC_WEBPACK_TRANSPILE_LOADER
+            },
+            {
+                test: /\.sql$/,
+                loader: 'raw-loader'
             }
         ]
     },
 
     plugins: [
         ionicWebpackFactory.getIonicEnvironmentPlugin(),
-        ionicWebpackFactory.getCommonChunksPlugin(),
         new webpack.DefinePlugin({
             ENV: JSON.stringify(envVars)
         })
-    ].concat(prodPlugins),
+    ],
 
     // Some libraries import Node modules but don't use them in the browser.
     // Tell Webpack to provide empty mocks for them so importing them works.


### PR DESCRIPTION
Primeiramente precisei retirar essa linha do seu package.json pois estava dando erro ao rodar o npm install:
http://prntscr.com/h50bol

Na raiz do seu projeto você vai criar uma pasta chamada typings, e dentro dessa pasta você vai criar um arquivo chamado sql.d.ts:
http://prntscr.com/h50fl8

O conteúdo do arquivo sql.d.ts será:

```
declare module "*.sql" {
    let sql: string;
    export = sql;
}
```

 

Isto é um tipo typescript, é para o webpack parar de mostrar aquele erro na compilação.

Agora você vai precisar adicionar mais uma dependencia no seu package.json, execute o comando:

`npm install @ionic/app-scripts@"^1.3.12" --save`

Você precisa do seguite loader no seu webpack.config.js:

```
 {
 
 test: /\.sql$/,
 
 loader: 'raw-loader'
 
 }
```

http://prntscr.com/h50mgf

Você pode substituir o conteúdo do seu webpack.config.js por esse:

https://github.com/NiltonMorais/CodeFlix/blob/master/codeflix-app/webpack.config.js

Baixe o raw-loader com o comando:

` npm install raw-loader --save`

Agora no seu tsconfig.json acrescente esse código:

```
 "files": [
         "typings/sql.d.ts"
   ] 
```

 http://prntscr.com/h50l9k

Depois disso consegui fazer o build normalmente:

http://prntscr.com/h511n8
